### PR TITLE
Replace 'devtools' option in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ ninja -C out/Release/ node  -j10
 
 Run Node with remote debugging enabled:
 ```text
-$ ./out/Release/node --devtools examples/test.js
+$ ./out/Release/node --remote-debugging-port=9222 examples/test.js
 ```
 
 The command will execute the script passed as the argument and start to wait for remote debugger


### PR DESCRIPTION
It's been removed and replaced with 'remote-debugging-port'. 